### PR TITLE
Moving to using FQDN for principal name for Impala

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -22,7 +22,7 @@ impala_log_file = os.path.join(impala_log_dir,'impala-setup.log')
 impala_catalog_host = config['clusterHostInfo']['impala_catalog_service_hosts'][0]
 impala_state_store_host = config['clusterHostInfo']['impala_state_store_hosts'][0]
 
-current_host_name = socket.gethostname()
+current_host_name = socket.getfqdn()
 
 security_enabled = config['configurations']['cluster-env']['security_enabled']
 


### PR DESCRIPTION
Updating params.py so that it pulls in the fully qualified domain name (FQDN) instead of just the hostname. The FQDN is the default used for principal names by Ambari, so using just the host name results in the inability for Impala to start up in a secured environment, since the principals don't match.

I made this change on a cluster we were trying to get to use the original pull, and it allowed us to implement the MPack on the Kerberized cluster correctly.